### PR TITLE
Fix incorrect single-use inlining across exclusive branches

### DIFF
--- a/src/ir/optimize/inline/apply/index.ts
+++ b/src/ir/optimize/inline/apply/index.ts
@@ -1,5 +1,6 @@
 import { myMapGet } from '../../../../utils/MyMap.js'
 import { IR } from '../../../nodes/index.js'
+import { Set as SetIR } from '../../../nodes/Set.js'
 import { replaceIR } from '../../../replace/index.js'
 import { CountInlineState } from '../count/state.js'
 import { FindInlineStates } from '../find/state.js'
@@ -9,6 +10,7 @@ export const applyInlineIR = (
     sideEffects: Set<IR>,
     countState: CountInlineState,
     findStates: FindInlineStates,
+    merged: ReadonlySet<SetIR>,
 ): { ir: IR; changed: boolean } => {
     const replacements = new Map(
         [...findStates.entries()].flatMap(([ir, state]): [IR, IR][] => {
@@ -16,6 +18,8 @@ export const applyInlineIR = (
 
             const element = myMapGet(state, ir.target)
             if (!element || element === 'T') return []
+
+            if (merged.has(element)) return []
 
             const count = myMapGet(countState.counts, element)
             if (count !== 1) return []

--- a/src/ir/optimize/inline/find/index.ts
+++ b/src/ir/optimize/inline/find/index.ts
@@ -1,19 +1,25 @@
 import { dataAnalysisForwardIR } from '../../../dataflowAnalysis/forward/index.js'
 import { IR } from '../../../nodes/index.js'
+import { Set } from '../../../nodes/Set.js'
 import { compareFindInlineStates } from './compare.js'
 import { meetFindInlineStates } from './meet.js'
 import { FindInlineState, FindInlineStates } from './state.js'
 import { transferFindInlineIR } from './transfer/index.js'
 
-export const findInlineIR = (ir: IR, irs: IR[]): FindInlineStates => {
+export const findInlineIR = (
+    ir: IR,
+    irs: IR[],
+): { states: FindInlineStates; merged: ReadonlySet<Set> } => {
     const input: FindInlineState = []
     const states: FindInlineStates = new Map(irs.map((ir) => [ir, []]))
 
+    const merged = new globalThis.Set<Set>()
+
     dataAnalysisForwardIR(ir, irs, input, states, {
         transfer: transferFindInlineIR,
-        meet: meetFindInlineStates,
+        meet: (a, b) => meetFindInlineStates(a, b, merged),
         compare: compareFindInlineStates,
     })
 
-    return states
+    return { states, merged }
 }

--- a/src/ir/optimize/inline/find/meet.ts
+++ b/src/ir/optimize/inline/find/meet.ts
@@ -1,13 +1,28 @@
 import { myMapMerge } from '../../../../utils/MyMap.js'
+import { Set } from '../../../nodes/Set.js'
 import { FindInlineState } from './state.js'
 
-export const meetFindInlineStates = (a: FindInlineState, b: FindInlineState): FindInlineState =>
+export const meetFindInlineStates = (
+    a: FindInlineState,
+    b: FindInlineState,
+    merged: globalThis.Set<Set>,
+): FindInlineState =>
     a === b
         ? a
         : myMapMerge(a, b, (valueA, valueB) => {
-              if (valueA === 'T' || valueB === 'T') return 'T'
+              if (valueA === 'T' || valueB === 'T') {
+                  if (valueA && valueA !== 'T') merged.add(valueA)
+                  if (valueB && valueB !== 'T') merged.add(valueB)
+
+                  return 'T'
+              }
 
               if (!valueA || !valueB) return valueA ?? valueB
 
-              return valueA === valueB ? valueA : 'T'
+              if (valueA === valueB) return valueA
+
+              merged.add(valueA)
+              merged.add(valueB)
+
+              return 'T'
           })

--- a/src/ir/optimize/inline/index.ts
+++ b/src/ir/optimize/inline/index.ts
@@ -17,7 +17,7 @@ export const inlineIR = (ir: IR): { ir: IR; changed: boolean } => {
 
     const countState = countInlineIR(ir, irs, trackCtx.dependencies)
 
-    const findStates = findInlineIR(ir, irs)
+    const { states: findStates, merged } = findInlineIR(ir, irs)
 
-    return applyInlineIR(ir, trackCtx.sideEffects, countState, findStates)
+    return applyInlineIR(ir, trackCtx.sideEffects, countState, findStates, merged)
 }


### PR DESCRIPTION
The inline pass forwards a Set's value into its Get and removes the Set when the value is read at most once dynamically. The count analysis tracked reads as 1 | T, so its meet could not distinguish one read shared by both branches of a join (rejoining the same Get) from two distinct reads on mutually exclusive paths. In the latter case the Set was removed while only one of the reads was rewritten, leaving the other read observing uninitialized memory.

Reproduced with: block memory write, read into a local, a multi-case switch (or if chains) using the local, then a use after the join - the post-join use evaluated to 0.

Track the reading Get node identity instead of 1 (meet: same node stays, different nodes become T), and only apply the rewrite when the counted reader is exactly the Get being replaced.